### PR TITLE
Support for reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ can be achieved with few data stores.
 
 ## Features
 - Synchronous replication of user-defined datasets
+- Support for reads using leader leases
 - Support for addition & removal of replicas at runtime
 - Periodic data consistency checks across replicas [TODO]
 
@@ -52,17 +53,17 @@ the example sync replication service to make changes to these 3 keyspaces synchr
 Launch the following 3 commands in separate terminal sessions:
 ```bash
 $ <PROJECT_ROOT>/bin/redis_repl \
-      -nexusPort 9121 \
+      -grpcPort 9121 \
       -nexusClusterUrl "http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
       -nexusNodeId 1 \
       -redisPort 6379
 $ <PROJECT_ROOT>/bin/redis_repl \
-      -nexusPort 9122 \
+      -grpcPort 9122 \
       -nexusClusterUrl "http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
       -nexusNodeId 2 \
       -redisPort 6380
 $ <PROJECT_ROOT>/bin/redis_repl \
-      -nexusPort 9123 \
+      -grpcPort 9123 \
       -nexusClusterUrl "http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
       -nexusNodeId 3 \
       -redisPort 6381
@@ -70,11 +71,16 @@ $ <PROJECT_ROOT>/bin/redis_repl \
 
 In a separate terminal session, launch the `repl` utility:
 ```bash
-$ <PROJECT_ROOT>/bin/repl redis 127.0.0.1:9121
-redis> redis.call('set', 'hello', 'world')
-OK
-redis> redis.call('set', 'foo', 'bar')
-OK
+$ <PROJECT_ROOT>/bin/repl redis 127.0.0.1:9121 save "return redis.call('set', 'hello', 'world')"
+Response from Redis (without quotes): 'OK'
+$ <PROJECT_ROOT>/bin/repl redis 127.0.0.1:9121 save "return redis.call('incr', 'ctr')"
+Response from Redis (without quotes): '1'
+$ <PROJECT_ROOT>/bin/repl redis 127.0.0.1:9121 save "return redis.call('incr', 'ctr')"
+Response from Redis (without quotes): '2'
+$ <PROJECT_ROOT>/bin/repl redis 127.0.0.1:9121 load "return redis.call('keys', '*')"
+Response from Redis (without quotes): '[ctr hello]'
+$ <PROJECT_ROOT>/bin/repl redis 127.0.0.1:9121 load "return redis.call('get', 'ctr')"
+Response from Redis (without quotes): '2'
 ```
 
 Any valid command can be issued to Redis as a Lua statement. Please refer to [EVAL](https://redis.io/commands/eval) for more details.
@@ -95,17 +101,17 @@ examples to work, please first create a database named `nexus` in each of the 3 
 Launch the following 3 commands in separate terminal sessions:
 ```bash
 $ <PROJECT_ROOT>/bin/mysql_repl \
-      -nexusPort=9121 \
+      -grpcPort=9121 \
       -nexusClusterUrl="http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
       -nexusNodeId=1 \
       -mysqlConnUrl "root:root@tcp(127.0.0.1:33061)/nexus?autocommit=false"
 $ <PROJECT_ROOT>/bin/mysql_repl \
-      -nexusPort=9122 \
+      -grpcPort=9122 \
       -nexusClusterUrl="http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
       -nexusNodeId=2 \
       -mysqlConnUrl "root:root@tcp(127.0.0.1:33062)/nexus?autocommit=false"
 $ <PROJECT_ROOT>/bin/mysql_repl \
-      -nexusPort=9123 \
+      -grpcPort=9123 \
       -nexusClusterUrl="http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
       -nexusNodeId=3 \
       -mysqlConnUrl "root:root@tcp(127.0.0.1:33063)/nexus?autocommit=false"
@@ -113,18 +119,23 @@ $ <PROJECT_ROOT>/bin/mysql_repl \
 
 In a separate terminal session, launch the `repl` utility:
 ```bash
-$ <PROJECT_ROOT>/bin/repl mysql 127.0.0.1:9121
-mysql> create table sync_table (id INT PRIMARY KEY AUTO_INCREMENT, data VARCHAR(50) NOT NULL, ts timestamp(3) default current_timestamp(3) on update current_timestamp(3));
-OK
-mysql> insert into sync_table (data) values ('hello world');
-OK
-mysql> insert into sync_table (data) values ('foo bar');
-OK
+# Create a sync_table in all the nodes
+$ <PROJECT_ROOT>/bin/repl mysql 127.0.0.1:9121 save "create table sync_table (id INT PRIMARY KEY AUTO_INCREMENT, data VARCHAR(50) NOT NULL, ts timestamp(3) default current_timestamp(3) on update current_timestamp(3));"
+
+# Insert some data into this table
+$ <PROJECT_ROOT>/bin/repl mysql 127.0.0.1:9121 save "insert into sync_table (name, data) values ('foo', 'bar');"
+$ <PROJECT_ROOT>/bin/repl mysql 127.0.0.1:9121 save "insert into sync_table (name, data) values ('hello', 'world');"
+
+# Load some data from this table
+$ <PROJECT_ROOT>/bin/repl mysql 127.0.0.1:9121 load "select * from nexus.sync_table;"
 ```
 
 Each of the 3 MySQL instances can now be inspected to ensure the table `sync_table` is created and it
 contains 2 rows in it. Likewise any arbitrary SQL statements can be issued for synchronous replication
 to all the 3 MySQL instances.
+
+### Reads based on leader leases
+By default, reads performed over Nexus perform a round trip with all the replicas and results are returned based on the quorum. This is done to provide linearizable guarantees. However, if the performance cost of this round trip is undesirable, the flag `-nexusLeaseBasedReads` can be used to avoid the round trip during read time and instead return the latest value so long as the lease is active on the serving node. Periodically messages are exchanged with other replicas in order to ensure the current lease is still active.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ contains 2 rows in it. Likewise any arbitrary SQL statements can be issued for s
 to all the 3 MySQL instances.
 
 ### Reads based on leader leases
-By default, reads performed over Nexus perform a round trip with all the replicas and results are returned based on the quorum. This is done to provide linearizable guarantees. However, if the performance cost of this round trip is undesirable, the flag `-nexusLeaseBasedReads` can be used to avoid the round trip during read time and instead return the latest value so long as the lease is active on the serving node. Periodically messages are exchanged with other replicas in order to ensure the current lease is still active.
+By default, reads performed over Nexus perform a round trip with all the replicas and results are returned based on the quorum. This is done to provide linearizable guarantees. However, if the performance cost of this round trip during read time is undesirable, the flag `-nexusLeaseBasedReads` can be used to avoid it and instead return the local copy so long as the lease is active on the serving node. Periodically messages are exchanged with other replicas so as to ensure the current lease is still active.
+
+Note that in environments where there can be unbounded clock drifts, this lease based approach can return stale results (non-linearizable) when the lease holder assumes its lease validity longer than it should, based on its local clock.
 
 ## Testing
 

--- a/examples/mysql_repl/store/db.go
+++ b/examples/mysql_repl/store/db.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/gob"
-	"errors"
+	"fmt"
 	"log"
 	"text/template"
 	"time"
@@ -13,24 +13,43 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
+type LoadRequest struct {
+	StmtTmpl string
+	Params   map[string]interface{}
+}
+
+func (this *LoadRequest) FromBytes(data []byte) error {
+	buf := bytes.NewBuffer(data)
+	if err := gob.NewDecoder(buf).Decode(this); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (this *LoadRequest) ToBytes() ([]byte, error) {
+	return encode(this)
+}
+
 type SaveRequest struct {
 	StmtTmpl string
 	Params   map[string]interface{}
 }
 
-func FromBytes(data []byte) (*SaveRequest, error) {
-	save_req := SaveRequest{}
+func (this *SaveRequest) FromBytes(data []byte) error {
 	buf := bytes.NewBuffer(data)
-	if err := gob.NewDecoder(buf).Decode(&save_req); err != nil {
-		return nil, err
-	} else {
-		return &save_req, nil
+	if err := gob.NewDecoder(buf).Decode(this); err != nil {
+		return err
 	}
+	return nil
 }
 
 func (this *SaveRequest) ToBytes() ([]byte, error) {
+	return encode(this)
+}
+
+func encode(obj interface{}) ([]byte, error) {
 	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(this); err != nil {
+	if err := gob.NewEncoder(&buf).Encode(obj); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
@@ -58,31 +77,83 @@ func (this *mysqlStore) Close() error {
 
 const txTimeout = 5 * time.Second // TODO: Should be configurable
 
-func (this *mysqlStore) save(sqlStmt string) error {
+func (this *mysqlStore) load(sqlStmt string) (*sql.Rows, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), txTimeout)
+	defer cancel()
+
+	// TODO: Isolation level can be part of the SaveRequest itself ?
+	if tx, err := this.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: true}); err != nil {
+		return nil, err
+	} else {
+		log.Printf("About to execute SQL: %s", sqlStmt)
+		return tx.QueryContext(ctx, sqlStmt)
+	}
+}
+
+func (this *mysqlStore) save(sqlStmt string) (sql.Result, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), txTimeout)
 	defer cancel()
 
 	// TODO: Isolation level can be part of the SaveRequest itself ?
 	if tx, err := this.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable}); err != nil {
-		return err
+		return nil, err
 	} else {
 		log.Printf("About to execute SQL: %s", sqlStmt)
-		if _, err := tx.ExecContext(ctx, sqlStmt); err != nil {
-			tx.Rollback() // TODO: Ignore rollback errors ?
-			return err
+		if res, err := tx.ExecContext(ctx, sqlStmt); err != nil {
+			tx.Rollback()
+			return nil, err
 		} else {
 			log.Printf("Successfully executed SQL: %s", sqlStmt)
-			return tx.Commit()
+			return res, tx.Commit()
 		}
 	}
 }
 
 func (this *mysqlStore) Load(data []byte) ([]byte, error) {
-	return nil, errors.New("Not implemented yet")
+	var load_req LoadRequest
+	if err := load_req.FromBytes(data); err != nil {
+		return nil, err
+	} else {
+		sql := load_req.StmtTmpl
+		if tmpl, err := template.New("sql_tmpl").Parse(sql); err != nil {
+			return nil, err
+		} else {
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, load_req.Params); err != nil {
+				return nil, err
+			} else {
+				if rows, err := this.load(buf.String()); err != nil {
+					return nil, err
+				} else {
+					defer rows.Close()
+					var results []map[string]interface{}
+					cols, _ := rows.Columns()
+					for rows.Next() {
+						columns := make([]interface{}, len(cols))
+						columnPointers := make([]interface{}, len(cols))
+						for i, _ := range columns {
+							columnPointers[i] = &columns[i]
+						}
+						if err := rows.Scan(columnPointers...); err != nil {
+							return nil, err
+						}
+						row := make(map[string]interface{})
+						for i, colName := range cols {
+							val := columnPointers[i].(*interface{})
+							row[colName] = *val
+						}
+						results = append(results, row)
+					}
+					return []byte(fmt.Sprintf("%v", results)), rows.Err()
+				}
+			}
+		}
+	}
 }
 
 func (this *mysqlStore) Save(data []byte) ([]byte, error) {
-	if save_req, err := FromBytes(data); err != nil {
+	var save_req SaveRequest
+	if err := save_req.FromBytes(data); err != nil {
 		return nil, err
 	} else {
 		sql := save_req.StmtTmpl
@@ -93,7 +164,11 @@ func (this *mysqlStore) Save(data []byte) ([]byte, error) {
 			if err := tmpl.Execute(&buf, save_req.Params); err != nil {
 				return nil, err
 			} else {
-				return nil, this.save(buf.String())
+				if res, err := this.save(buf.String()); err != nil {
+					return nil, err
+				} else {
+					return []byte(fmt.Sprintf("%#v", res)), nil
+				}
 			}
 		}
 	}

--- a/examples/mysql_repl/store/db.go
+++ b/examples/mysql_repl/store/db.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/gob"
+	"errors"
 	"log"
 	"text/template"
 	"time"
@@ -74,6 +75,10 @@ func (this *mysqlStore) save(sqlStmt string) error {
 			return tx.Commit()
 		}
 	}
+}
+
+func (this *mysqlStore) Load(data []byte) ([]byte, error) {
+	return nil, errors.New("Not implemented yet")
 }
 
 func (this *mysqlStore) Save(data []byte) ([]byte, error) {

--- a/examples/redis_repl/main.go
+++ b/examples/redis_repl/main.go
@@ -24,11 +24,11 @@ var (
 	stopChan  <-chan os.Signal
 	redisHost string
 	redisPort uint
-	nexusPort uint
+	grpcPort  uint
 )
 
 func init() {
-	flag.UintVar(&nexusPort, "nexusPort", 0, "Port on which Nexus GRPC server listens")
+	flag.UintVar(&grpcPort, "grpcPort", 0, "Port on which Nexus GRPC server listens")
 	flag.StringVar(&redisHost, "redisHost", "127.0.0.1", "Redis host")
 	flag.UintVar(&redisPort, "redisPort", 6379, "Redis port")
 	stopChan = setupSignalNotify()
@@ -40,7 +40,7 @@ func main() {
 		panic(err)
 	} else {
 		repl, _ := api.NewRaftReplicator(db, raft.OptionsFromFlags()...)
-		ns := grpc.NewNexusService(nexusPort, repl)
+		ns := grpc.NewNexusService(grpcPort, repl)
 		go ns.ListenAndServe()
 		sig := <-stopChan
 		log.Printf("[WARN] Caught signal: %v. Shutting down...", sig)

--- a/examples/redis_repl/store/db.go
+++ b/examples/redis_repl/store/db.go
@@ -3,7 +3,6 @@ package store
 import (
 	"bytes"
 	"encoding/gob"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -23,11 +22,16 @@ func isRedisError(err error) bool {
 }
 
 func (this *redisStore) Load(data []byte) ([]byte, error) {
-	return nil, errors.New("Not implemented yet")
+	luaScript := string(data)
+	return this.evalLua(luaScript)
 }
 
 func (this *redisStore) Save(data []byte) ([]byte, error) {
 	luaScript := string(data)
+	return this.evalLua(luaScript)
+}
+
+func (this *redisStore) evalLua(luaScript string) ([]byte, error) {
 	if res, err := this.cli.Eval(luaScript, nil).Result(); isRedisError(err) {
 		return nil, err
 	} else {

--- a/examples/redis_repl/store/db.go
+++ b/examples/redis_repl/store/db.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -19,6 +20,10 @@ func (this *redisStore) Close() error {
 
 func isRedisError(err error) bool {
 	return err != nil && !strings.HasSuffix(strings.TrimSpace(err.Error()), "nil")
+}
+
+func (this *redisStore) Load(data []byte) ([]byte, error) {
+	return nil, errors.New("Not implemented yet")
 }
 
 func (this *redisStore) Save(data []byte) ([]byte, error) {

--- a/examples/repl/main.go
+++ b/examples/repl/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	str "strings"
@@ -11,7 +11,7 @@ import (
 )
 
 func printUsage() {
-	fmt.Printf("Usage: %s <mysql|redis> <nexus_url> [<expression>]\n", os.Args[0])
+	fmt.Printf("Usage: %s <mysql|redis> <nexus_url> load|save <expression>\n", os.Args[0])
 }
 
 func newNexusClient(nexus_url string) *grpc.NexusClient {
@@ -22,96 +22,81 @@ func newNexusClient(nexus_url string) *grpc.NexusClient {
 	}
 }
 
-func sendMySQLCmd(nc *grpc.NexusClient, cmd string) ([]byte, error) {
+func loadMySQLCmd(nc *grpc.NexusClient, cmd string) ([]byte, error) {
+	load_req := &mstore.LoadRequest{StmtTmpl: cmd}
+	if bts, err := load_req.ToBytes(); err != nil {
+		return nil, err
+	} else {
+		return nc.Load(bts)
+	}
+}
+
+func saveMySQLCmd(nc *grpc.NexusClient, cmd string) ([]byte, error) {
 	save_req := &mstore.SaveRequest{StmtTmpl: cmd}
 	if bts, err := save_req.ToBytes(); err != nil {
 		return nil, err
 	} else {
-		return nc.Replicate(bts)
+		return nc.Save(bts)
 	}
 }
 
-func sendRedisCmd(nc *grpc.NexusClient, cmd string) ([]byte, error) {
-	return nc.Replicate([]byte(cmd))
-}
-
-func sendMySQL(nexus_url string, cmd string) {
-	nc := newNexusClient(nexus_url)
-	defer nc.Close()
-
-	if res, err := sendMySQLCmd(nc, str.TrimSpace(cmd)); err != nil {
-		fmt.Println(err.Error())
-	} else {
-		fmt.Printf("Response from MySQL (without quotes): '%s'\n", res)
+func sendRedisCmd(nc *grpc.NexusClient, mode, cmd string) ([]byte, error) {
+	switch str.ToLower(mode) {
+	case "load":
+		return nc.Load([]byte(cmd))
+	case "save":
+		return nc.Save([]byte(cmd))
 	}
+	return nil, errors.New("Unknown mode: " + mode)
 }
 
-func replMySQL(nexus_url string) {
+func sendMySQL(nexus_url string, mode, cmd string) {
 	nc := newNexusClient(nexus_url)
 	defer nc.Close()
 
-	in := bufio.NewScanner(os.Stdin)
-	fmt.Print("mysql> ")
-	for in.Scan() {
-		cmd := in.Text()
-		if res, err := sendMySQLCmd(nc, str.TrimSpace(cmd)); err != nil {
+	switch str.ToLower(str.TrimSpace(mode)) {
+	case "load":
+		if res, err := loadMySQLCmd(nc, str.TrimSpace(cmd)); err != nil {
 			fmt.Println(err.Error())
 		} else {
 			fmt.Printf("Response from MySQL (without quotes): '%s'\n", res)
 		}
-		fmt.Print("mysql> ")
+	case "save":
+		if res, err := saveMySQLCmd(nc, str.TrimSpace(cmd)); err != nil {
+			fmt.Println(err.Error())
+		} else {
+			fmt.Printf("Response from MySQL (without quotes): '%s'\n", res)
+		}
+	default:
+		fmt.Printf("Unknown mode: " + mode)
 	}
+
 }
 
-func sendRedis(nexus_url string, cmd string) {
+func sendRedis(nexus_url string, mode, cmd string) {
 	nc := newNexusClient(nexus_url)
 	defer nc.Close()
 
-	if res, err := sendRedisCmd(nc, str.TrimSpace(cmd)); err != nil {
+	if res, err := sendRedisCmd(nc, str.TrimSpace(mode), str.TrimSpace(cmd)); err != nil {
 		fmt.Println(err.Error())
 	} else {
 		fmt.Printf("Response from Redis (without quotes): '%s'\n", res)
 	}
 }
 
-func replRedis(nexus_url string) {
-	nc := newNexusClient(nexus_url)
-	defer nc.Close()
-
-	in := bufio.NewScanner(os.Stdin)
-	fmt.Print("redis> ")
-	for in.Scan() {
-		cmd := in.Text()
-		if res, err := sendRedisCmd(nc, str.TrimSpace(cmd)); err != nil {
-			fmt.Println(err.Error())
-		} else {
-			fmt.Printf("Response from Redis (without quotes): '%s'\n", res)
-		}
-		fmt.Print("redis> ")
-	}
-}
-
 func main() {
 	arg_len := len(os.Args)
-	if arg_len < 3 || arg_len > 4 {
+	if arg_len != 5 {
 		printUsage()
 		return
 	}
 
-	db, nexus_url, repl_mode := str.ToLower(str.TrimSpace(os.Args[1])), str.TrimSpace(os.Args[2]), arg_len == 3
+	db, nexus_url := str.ToLower(str.TrimSpace(os.Args[1])), str.TrimSpace(os.Args[2])
 	switch db {
 	case "mysql":
-		if repl_mode {
-			replMySQL(nexus_url)
-		} else {
-			sendMySQL(nexus_url, os.Args[3])
-		}
+		sendMySQL(nexus_url, os.Args[3], os.Args[4])
 	case "redis":
-		if repl_mode {
-			replRedis(nexus_url)
-		} else {
-			sendRedis(nexus_url, os.Args[3])
-		}
+		sendRedis(nexus_url, os.Args[3], os.Args[4])
 	default:
 		printUsage()
 	}

--- a/internal/grpc/client.go
+++ b/internal/grpc/client.go
@@ -29,11 +29,26 @@ func NewInSecureNexusClient(svcAddr string) (*NexusClient, error) {
 	}
 }
 
-func (this *NexusClient) Replicate(data []byte) ([]byte, error) {
+func (this *NexusClient) Save(data []byte) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
 	defer cancel()
-	putReq := &api.ReplicateRequest{Data: data}
-	if res, err := this.nexusCli.Replicate(ctx, putReq); err != nil {
+	saveReq := &api.SaveRequest{Data: data}
+	if res, err := this.nexusCli.Save(ctx, saveReq); err != nil {
+		return nil, err
+	} else {
+		if res.Status.Code != 0 {
+			return nil, errors.New(res.Status.Message)
+		} else {
+			return res.Data, nil
+		}
+	}
+}
+
+func (this *NexusClient) Load(data []byte) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	defer cancel()
+	loadReq := &api.LoadRequest{Data: data}
+	if res, err := this.nexusCli.Load(ctx, loadReq); err != nil {
 		return nil, err
 	} else {
 		if res.Status.Code != 0 {

--- a/internal/grpc/client.go
+++ b/internal/grpc/client.go
@@ -12,7 +12,7 @@ import (
 const (
 	ReadBufSize  = 10 << 30
 	WriteBufSize = 10 << 30
-	Timeout      = 1 * time.Second
+	Timeout      = 10 * time.Second
 )
 
 type NexusClient struct {

--- a/internal/grpc/service.go
+++ b/internal/grpc/service.go
@@ -44,11 +44,19 @@ func (this *NexusService) Close() error {
 	return nil
 }
 
-func (this *NexusService) Replicate(ctx context.Context, req *api.ReplicateRequest) (*api.ReplicateResponse, error) {
+func (this *NexusService) Save(ctx context.Context, req *api.SaveRequest) (*api.SaveResponse, error) {
 	if res, err := this.repl.Save(ctx, req.Data); err != nil {
-		return &api.ReplicateResponse{Status: &api.Status{Code: -1, Message: err.Error()}, Data: nil}, err
+		return &api.SaveResponse{Status: &api.Status{Code: -1, Message: err.Error()}, Data: nil}, err
 	} else {
-		return &api.ReplicateResponse{Status: &api.Status{}, Data: res}, nil
+		return &api.SaveResponse{Status: &api.Status{}, Data: res}, nil
+	}
+}
+
+func (this *NexusService) Load(ctx context.Context, req *api.LoadRequest) (*api.LoadResponse, error) {
+	if res, err := this.repl.Load(ctx, req.Data); err != nil {
+		return &api.LoadResponse{Status: &api.Status{Code: -1, Message: err.Error()}, Data: nil}, err
+	} else {
+		return &api.LoadResponse{Status: &api.Status{}, Data: res}, nil
 	}
 }
 

--- a/internal/grpc/service.go
+++ b/internal/grpc/service.go
@@ -45,7 +45,7 @@ func (this *NexusService) Close() error {
 }
 
 func (this *NexusService) Replicate(ctx context.Context, req *api.ReplicateRequest) (*api.ReplicateResponse, error) {
-	if res, err := this.repl.Replicate(ctx, req.Data); err != nil {
+	if res, err := this.repl.Save(ctx, req.Data); err != nil {
 		return &api.ReplicateResponse{Status: &api.Status{Code: -1, Message: err.Error()}, Data: nil}, err
 	} else {
 		return &api.ReplicateResponse{Status: &api.Status{}, Data: res}, nil

--- a/internal/grpc/service_test.go
+++ b/internal/grpc/service_test.go
@@ -35,7 +35,7 @@ func TestNexusService(t *testing.T) {
 }
 
 func replicate(t *testing.T, nc *NexusClient, data []byte) {
-	if _, err := nc.Replicate(data); err != nil {
+	if _, err := nc.Save(data); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/grpc/service_test.go
+++ b/internal/grpc/service_test.go
@@ -59,7 +59,7 @@ func (this *mockRepl) Start() {
 func (this *mockRepl) Stop() {
 }
 
-func (this *mockRepl) Replicate(ctx context.Context, data []byte) ([]byte, error) {
+func (this *mockRepl) Save(ctx context.Context, data []byte) ([]byte, error) {
 	if hsh, err := hashCode(data); err != nil {
 		return nil, err
 	} else {

--- a/internal/grpc/service_test.go
+++ b/internal/grpc/service_test.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -57,6 +58,11 @@ func (this *mockRepl) Start() {
 }
 
 func (this *mockRepl) Stop() {
+}
+
+func (this *mockRepl) Load(ctx context.Context, data []byte) ([]byte, error) {
+	id := binary.BigEndian.Uint32(data)
+	return this.data[id], nil
 }
 
 func (this *mockRepl) Save(ctx context.Context, data []byte) ([]byte, error) {

--- a/internal/raft/node.go
+++ b/internal/raft/node.go
@@ -41,8 +41,8 @@ import (
 // A key-value stream backed by raft
 type raftNode struct {
 	readStateC chan raft.ReadState // to send out readState
-	commitC    chan<- []byte       // entries committed to log (k,v)
-	errorC     chan<- error        // errors from raft session
+	commitC    chan []byte         // entries committed to log (k,v)
+	errorC     chan error          // errors from raft session
 
 	id          int      // client ID for raft session
 	peers       []string // raft peer URLs
@@ -78,7 +78,7 @@ var defaultSnapshotCount uint64 = 0
 // provided the proposal channel. All log entries are replayed over the
 // commit channel, followed by a nil message (to indicate the channel is
 // current), then new log entries. To shutdown, close proposeC and read errorC.
-func NewRaftNode(opts pkg_raft.Options, getSnapshot func() ([]byte, error)) (*raftNode, <-chan raft.ReadState, <-chan []byte, <-chan error, <-chan struct{}) {
+func NewRaftNode(opts pkg_raft.Options, getSnapshot func() ([]byte, error)) *raftNode {
 
 	readStateC := make(chan raft.ReadState)
 	commitC := make(chan []byte)
@@ -101,7 +101,7 @@ func NewRaftNode(opts pkg_raft.Options, getSnapshot func() ([]byte, error)) (*ra
 		snapshotterReady: make(chan struct{}),
 		// rest of structure populated after WAL replay
 	}
-	return rc, readStateC, commitC, errorC, rc.snapshotterReady
+	return rc
 }
 
 func (rc *raftNode) saveSnap(snap raftpb.Snapshot) error {

--- a/internal/raft/node.go
+++ b/internal/raft/node.go
@@ -245,7 +245,7 @@ func (rc *raftNode) writeError(err error) {
 	rc.node.Stop()
 }
 
-func (rc *raftNode) startRaft() {
+func (rc *raftNode) startRaft(readOption raft.ReadOnlyOption) {
 	if !fileutil.Exist(rc.snapdir) {
 		if err := os.Mkdir(rc.snapdir, 0750); err != nil {
 			log.Fatalf("nexus.raft: [Node %v] cannot create dir for snapshot (%v)", rc.id, err)
@@ -267,6 +267,8 @@ func (rc *raftNode) startRaft() {
 		Storage:         rc.raftStorage,
 		MaxSizePerMsg:   1024 * 1024,
 		MaxInflightMsgs: 256,
+		ReadOnlyOption:  readOption,
+		CheckQuorum:     readOption == raft.ReadOnlyLeaseBased,
 	}
 
 	if oldwal {

--- a/internal/raft/node.go
+++ b/internal/raft/node.go
@@ -40,8 +40,9 @@ import (
 
 // A key-value stream backed by raft
 type raftNode struct {
-	commitC chan<- []byte // entries committed to log (k,v)
-	errorC  chan<- error  // errors from raft session
+	readStateC chan raft.ReadState // to send out readState
+	commitC    chan<- []byte       // entries committed to log (k,v)
+	errorC     chan<- error        // errors from raft session
 
 	id          int      // client ID for raft session
 	peers       []string // raft peer URLs
@@ -77,12 +78,14 @@ var defaultSnapshotCount uint64 = 0
 // provided the proposal channel. All log entries are replayed over the
 // commit channel, followed by a nil message (to indicate the channel is
 // current), then new log entries. To shutdown, close proposeC and read errorC.
-func NewRaftNode(opts pkg_raft.Options, getSnapshot func() ([]byte, error)) (*raftNode, <-chan []byte, <-chan error, <-chan struct{}) {
+func NewRaftNode(opts pkg_raft.Options, getSnapshot func() ([]byte, error)) (*raftNode, <-chan raft.ReadState, <-chan []byte, <-chan error, <-chan struct{}) {
 
+	readStateC := make(chan raft.ReadState)
 	commitC := make(chan []byte)
 	errorC := make(chan error)
 
 	rc := &raftNode{
+		readStateC:       readStateC,
 		commitC:          commitC,
 		errorC:           errorC,
 		id:               opts.NodeId(),
@@ -98,7 +101,7 @@ func NewRaftNode(opts pkg_raft.Options, getSnapshot func() ([]byte, error)) (*ra
 		snapshotterReady: make(chan struct{}),
 		// rest of structure populated after WAL replay
 	}
-	return rc, commitC, errorC, rc.snapshotterReady
+	return rc, readStateC, commitC, errorC, rc.snapshotterReady
 }
 
 func (rc *raftNode) saveSnap(snap raftpb.Snapshot) error {
@@ -379,6 +382,19 @@ func (rc *raftNode) maybeTriggerSnapshot() {
 	rc.snapshotIndex = rc.appliedIndex
 }
 
+func (rc *raftNode) publishReadStates(readStates []raft.ReadState) bool {
+	// TODO: We can just publish the latest read state like etcd
+	for _, rs := range readStates {
+		select {
+		case rc.readStateC <- rs:
+		case <-rc.stopc:
+			return false
+		}
+	}
+
+	return true
+}
+
 func (rc *raftNode) serveChannels() {
 	snap, err := rc.raftStorage.Snapshot()
 	if err != nil {
@@ -401,6 +417,10 @@ func (rc *raftNode) serveChannels() {
 
 		// store raft entries to wal, then publish over commit channel
 		case rd := <-rc.node.Ready():
+			if ok := rc.publishReadStates(rd.ReadStates); !ok {
+				rc.stop()
+				return
+			}
 			rc.wal.Save(rd.HardState, rd.Entries)
 			if !raft.IsEmptySnap(rd.Snapshot) {
 				rc.saveSnap(rd.Snapshot)

--- a/internal/raft/replicator.go
+++ b/internal/raft/replicator.go
@@ -63,7 +63,7 @@ func (this *replicator) Start() {
 	go this.readCommits()
 }
 
-func (this *replicator) Replicate(ctx context.Context, data []byte) ([]byte, error) {
+func (this *replicator) Save(ctx context.Context, data []byte) ([]byte, error) {
 	// TODO: Validate raft state to check if Start() has been invoked
 	repl_req := &internalNexusRequest{ID: this.idGen.Next(), Req: data}
 	if repl_req_data, err := repl_req.marshal(); err != nil {

--- a/internal/raft/replicator_test.go
+++ b/internal/raft/replicator_test.go
@@ -39,15 +39,15 @@ func testSaveData(t *testing.T) {
 	var reqs []*kvReq
 	for _, peer := range clus.peers {
 		req1 := &kvReq{fmt.Sprintf("Key:%d#%d", peer.id, 1), time.Now().Unix()}
-		peer.replicate(t, req1)
+		peer.save(t, req1)
 		reqs = append(reqs, req1)
 
 		req2 := &kvReq{fmt.Sprintf("Key:%d#%d", peer.id, 2), time.Now().Unix()}
-		peer.replicate(t, req2)
+		peer.save(t, req2)
 		reqs = append(reqs, req2)
 
 		req3 := &kvReq{fmt.Sprintf("Key:%d#%d", peer.id, 3), time.Now().Unix()}
-		peer.replicate(t, req3)
+		peer.save(t, req3)
 		reqs = append(reqs, req3)
 	}
 	clus.assertDB(t, reqs...)
@@ -80,8 +80,8 @@ func testForNewNexusNodeJoinLeaveCluster(t *testing.T) {
 func testForNodeRestart(t *testing.T) {
 	peer2 := clus.peers[1]
 	reqs := []*kvReq{&kvReq{"hello", "world"}, &kvReq{"foo", "bar"}}
-	peer2.replicate(t, reqs[0])
-	peer2.replicate(t, reqs[1])
+	peer2.save(t, reqs[0])
+	peer2.save(t, reqs[1])
 	clus.assertDB(t, reqs...)
 
 	peer2.stop()
@@ -89,8 +89,8 @@ func testForNodeRestart(t *testing.T) {
 
 	peer1 := clus.peers[0]
 	new_reqs := []*kvReq{&kvReq{"micro", "soft"}, &kvReq{"wel", "come"}}
-	peer1.replicate(t, new_reqs[0])
-	peer1.replicate(t, new_reqs[1])
+	peer1.save(t, new_reqs[0])
+	peer1.save(t, new_reqs[1])
 
 	var err error
 	peer2, err = newPeerWithDB(2, peer2.db)
@@ -209,11 +209,11 @@ func (this *peer) stop() {
 	this.repl.Stop()
 }
 
-func (this *peer) replicate(t *testing.T, req *kvReq) {
+func (this *peer) save(t *testing.T, req *kvReq) {
 	if bts, err := req.toBytes(); err != nil {
 		t.Fatal(err)
 	} else {
-		if _, err := this.repl.Replicate(context.Background(), bts); err != nil {
+		if _, err := this.repl.Save(context.Background(), bts); err != nil {
 			t.Fatal(err)
 		} else {
 			sleep(1)

--- a/internal/raft/replicator_test.go
+++ b/internal/raft/replicator_test.go
@@ -226,10 +226,9 @@ func (this *cluster) assertDB(t *testing.T, reqs ...*kvReq) {
 }
 
 type peer struct {
-	id             int
-	db             *inMemKVStore
-	repl           *replicator
-	bakReplTimeout time.Duration
+	id   int
+	db   *inMemKVStore
+	repl *replicator
 }
 
 func newPeerWithDB(id int, db *inMemKVStore) (*peer, error) {
@@ -239,12 +238,13 @@ func newPeerWithDB(id int, db *inMemKVStore) (*peer, error) {
 		raft.SnapDir(snapDir),
 		raft.ClusterUrl(clusterUrl),
 		raft.ReplicationTimeout(replTimeout),
+		raft.LeaseBasedReads(),
 	)
 	if err != nil {
 		return nil, err
 	} else {
 		repl := NewReplicator(db, opts)
-		return &peer{id, db, repl, repl.replTimeout}, nil
+		return &peer{id, db, repl}, nil
 	}
 }
 
@@ -260,6 +260,7 @@ func newJoiningPeer(id int, clusUrl string) (*peer, error) {
 		raft.SnapDir(snapDir),
 		raft.ClusterUrl(clusUrl),
 		raft.ReplicationTimeout(replTimeout),
+		raft.LeaseBasedReads(),
 		raft.Join(true), // `true` since this node is joining an existing cluster
 	)
 	if err != nil {
@@ -267,7 +268,7 @@ func newJoiningPeer(id int, clusUrl string) (*peer, error) {
 	} else {
 		db := newInMemKVStore()
 		repl := NewReplicator(db, opts)
-		return &peer{id, db, repl, repl.replTimeout}, nil
+		return &peer{id, db, repl}, nil
 	}
 }
 

--- a/pkg/api/nexus.go
+++ b/pkg/api/nexus.go
@@ -11,7 +11,7 @@ import (
 
 type RaftReplicator interface {
 	Start()
-	Replicate(context.Context, []byte) ([]byte, error)
+	Save(context.Context, []byte) ([]byte, error)
 	AddMember(context.Context, int, string) error
 	RemoveMember(context.Context, int) error
 	Stop()

--- a/pkg/api/nexus.go
+++ b/pkg/api/nexus.go
@@ -12,6 +12,7 @@ import (
 type RaftReplicator interface {
 	Start()
 	Save(context.Context, []byte) ([]byte, error)
+	Load(context.Context, []byte) ([]byte, error)
 	AddMember(context.Context, int, string) error
 	RemoveMember(context.Context, int) error
 	Stop()

--- a/pkg/api/nexus.pb.go
+++ b/pkg/api/nexus.pb.go
@@ -71,7 +71,46 @@ func (m *Status) GetMessage() string {
 	return ""
 }
 
-type ReplicateResponse struct {
+type SaveRequest struct {
+	Data                 []byte   `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *SaveRequest) Reset()         { *m = SaveRequest{} }
+func (m *SaveRequest) String() string { return proto.CompactTextString(m) }
+func (*SaveRequest) ProtoMessage()    {}
+func (*SaveRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_6bc6d570457f57a9, []int{1}
+}
+
+func (m *SaveRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SaveRequest.Unmarshal(m, b)
+}
+func (m *SaveRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SaveRequest.Marshal(b, m, deterministic)
+}
+func (m *SaveRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SaveRequest.Merge(m, src)
+}
+func (m *SaveRequest) XXX_Size() int {
+	return xxx_messageInfo_SaveRequest.Size(m)
+}
+func (m *SaveRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SaveRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SaveRequest proto.InternalMessageInfo
+
+func (m *SaveRequest) GetData() []byte {
+	if m != nil {
+		return m.Data
+	}
+	return nil
+}
+
+type SaveResponse struct {
 	Status               *Status  `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	Data                 []byte   `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -79,78 +118,125 @@ type ReplicateResponse struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ReplicateResponse) Reset()         { *m = ReplicateResponse{} }
-func (m *ReplicateResponse) String() string { return proto.CompactTextString(m) }
-func (*ReplicateResponse) ProtoMessage()    {}
-func (*ReplicateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_6bc6d570457f57a9, []int{1}
+func (m *SaveResponse) Reset()         { *m = SaveResponse{} }
+func (m *SaveResponse) String() string { return proto.CompactTextString(m) }
+func (*SaveResponse) ProtoMessage()    {}
+func (*SaveResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_6bc6d570457f57a9, []int{2}
 }
 
-func (m *ReplicateResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ReplicateResponse.Unmarshal(m, b)
+func (m *SaveResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SaveResponse.Unmarshal(m, b)
 }
-func (m *ReplicateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ReplicateResponse.Marshal(b, m, deterministic)
+func (m *SaveResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SaveResponse.Marshal(b, m, deterministic)
 }
-func (m *ReplicateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReplicateResponse.Merge(m, src)
+func (m *SaveResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SaveResponse.Merge(m, src)
 }
-func (m *ReplicateResponse) XXX_Size() int {
-	return xxx_messageInfo_ReplicateResponse.Size(m)
+func (m *SaveResponse) XXX_Size() int {
+	return xxx_messageInfo_SaveResponse.Size(m)
 }
-func (m *ReplicateResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ReplicateResponse.DiscardUnknown(m)
+func (m *SaveResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SaveResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ReplicateResponse proto.InternalMessageInfo
+var xxx_messageInfo_SaveResponse proto.InternalMessageInfo
 
-func (m *ReplicateResponse) GetStatus() *Status {
+func (m *SaveResponse) GetStatus() *Status {
 	if m != nil {
 		return m.Status
 	}
 	return nil
 }
 
-func (m *ReplicateResponse) GetData() []byte {
+func (m *SaveResponse) GetData() []byte {
 	if m != nil {
 		return m.Data
 	}
 	return nil
 }
 
-type ReplicateRequest struct {
+type LoadRequest struct {
 	Data                 []byte   `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ReplicateRequest) Reset()         { *m = ReplicateRequest{} }
-func (m *ReplicateRequest) String() string { return proto.CompactTextString(m) }
-func (*ReplicateRequest) ProtoMessage()    {}
-func (*ReplicateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_6bc6d570457f57a9, []int{2}
+func (m *LoadRequest) Reset()         { *m = LoadRequest{} }
+func (m *LoadRequest) String() string { return proto.CompactTextString(m) }
+func (*LoadRequest) ProtoMessage()    {}
+func (*LoadRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_6bc6d570457f57a9, []int{3}
 }
 
-func (m *ReplicateRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ReplicateRequest.Unmarshal(m, b)
+func (m *LoadRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_LoadRequest.Unmarshal(m, b)
 }
-func (m *ReplicateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ReplicateRequest.Marshal(b, m, deterministic)
+func (m *LoadRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_LoadRequest.Marshal(b, m, deterministic)
 }
-func (m *ReplicateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReplicateRequest.Merge(m, src)
+func (m *LoadRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LoadRequest.Merge(m, src)
 }
-func (m *ReplicateRequest) XXX_Size() int {
-	return xxx_messageInfo_ReplicateRequest.Size(m)
+func (m *LoadRequest) XXX_Size() int {
+	return xxx_messageInfo_LoadRequest.Size(m)
 }
-func (m *ReplicateRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ReplicateRequest.DiscardUnknown(m)
+func (m *LoadRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_LoadRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ReplicateRequest proto.InternalMessageInfo
+var xxx_messageInfo_LoadRequest proto.InternalMessageInfo
 
-func (m *ReplicateRequest) GetData() []byte {
+func (m *LoadRequest) GetData() []byte {
+	if m != nil {
+		return m.Data
+	}
+	return nil
+}
+
+type LoadResponse struct {
+	Status               *Status  `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	Data                 []byte   `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *LoadResponse) Reset()         { *m = LoadResponse{} }
+func (m *LoadResponse) String() string { return proto.CompactTextString(m) }
+func (*LoadResponse) ProtoMessage()    {}
+func (*LoadResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_6bc6d570457f57a9, []int{4}
+}
+
+func (m *LoadResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_LoadResponse.Unmarshal(m, b)
+}
+func (m *LoadResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_LoadResponse.Marshal(b, m, deterministic)
+}
+func (m *LoadResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LoadResponse.Merge(m, src)
+}
+func (m *LoadResponse) XXX_Size() int {
+	return xxx_messageInfo_LoadResponse.Size(m)
+}
+func (m *LoadResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_LoadResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_LoadResponse proto.InternalMessageInfo
+
+func (m *LoadResponse) GetStatus() *Status {
+	if m != nil {
+		return m.Status
+	}
+	return nil
+}
+
+func (m *LoadResponse) GetData() []byte {
 	if m != nil {
 		return m.Data
 	}
@@ -169,7 +255,7 @@ func (m *AddNodeRequest) Reset()         { *m = AddNodeRequest{} }
 func (m *AddNodeRequest) String() string { return proto.CompactTextString(m) }
 func (*AddNodeRequest) ProtoMessage()    {}
 func (*AddNodeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_6bc6d570457f57a9, []int{3}
+	return fileDescriptor_6bc6d570457f57a9, []int{5}
 }
 
 func (m *AddNodeRequest) XXX_Unmarshal(b []byte) error {
@@ -215,7 +301,7 @@ func (m *RemoveNodeRequest) Reset()         { *m = RemoveNodeRequest{} }
 func (m *RemoveNodeRequest) String() string { return proto.CompactTextString(m) }
 func (*RemoveNodeRequest) ProtoMessage()    {}
 func (*RemoveNodeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_6bc6d570457f57a9, []int{4}
+	return fileDescriptor_6bc6d570457f57a9, []int{6}
 }
 
 func (m *RemoveNodeRequest) XXX_Unmarshal(b []byte) error {
@@ -245,8 +331,10 @@ func (m *RemoveNodeRequest) GetNodeId() uint32 {
 
 func init() {
 	proto.RegisterType((*Status)(nil), "nexus.api.Status")
-	proto.RegisterType((*ReplicateResponse)(nil), "nexus.api.ReplicateResponse")
-	proto.RegisterType((*ReplicateRequest)(nil), "nexus.api.ReplicateRequest")
+	proto.RegisterType((*SaveRequest)(nil), "nexus.api.SaveRequest")
+	proto.RegisterType((*SaveResponse)(nil), "nexus.api.SaveResponse")
+	proto.RegisterType((*LoadRequest)(nil), "nexus.api.LoadRequest")
+	proto.RegisterType((*LoadResponse)(nil), "nexus.api.LoadResponse")
 	proto.RegisterType((*AddNodeRequest)(nil), "nexus.api.AddNodeRequest")
 	proto.RegisterType((*RemoveNodeRequest)(nil), "nexus.api.RemoveNodeRequest")
 }
@@ -254,25 +342,26 @@ func init() {
 func init() { proto.RegisterFile("nexus.proto", fileDescriptor_6bc6d570457f57a9) }
 
 var fileDescriptor_6bc6d570457f57a9 = []byte{
-	// 275 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x52, 0x3d, 0x4f, 0xc3, 0x30,
-	0x10, 0x95, 0x81, 0xa4, 0xca, 0x15, 0x10, 0xbd, 0x01, 0x85, 0xc2, 0x50, 0x65, 0x40, 0x45, 0x48,
-	0x19, 0x8a, 0x04, 0x13, 0x03, 0x1d, 0x90, 0x58, 0x3a, 0x18, 0xb1, 0xb0, 0x99, 0xfa, 0x84, 0x22,
-	0xb5, 0xb1, 0xa9, 0x1d, 0xc4, 0x3f, 0xe4, 0x6f, 0x21, 0xbb, 0x6e, 0x70, 0x4b, 0x06, 0xb6, 0xf7,
-	0x94, 0x97, 0xf7, 0x71, 0x32, 0xf4, 0x6b, 0xfa, 0x6a, 0x4c, 0xa9, 0x57, 0xca, 0x2a, 0xcc, 0xd6,
-	0x44, 0xe8, 0xaa, 0xb8, 0x85, 0xf4, 0xd9, 0x0a, 0xdb, 0x18, 0x44, 0x38, 0x98, 0x2b, 0x49, 0x39,
-	0x1b, 0xb1, 0x71, 0xc2, 0x3d, 0xc6, 0x1c, 0x7a, 0x4b, 0x32, 0x46, 0xbc, 0x53, 0xbe, 0x37, 0x62,
-	0xe3, 0x8c, 0x6f, 0x68, 0xc1, 0x61, 0xc0, 0x49, 0x2f, 0xaa, 0xb9, 0xb0, 0xc4, 0xc9, 0x68, 0x55,
-	0x1b, 0xc2, 0x2b, 0x48, 0x8d, 0x37, 0xf3, 0x26, 0xfd, 0xc9, 0xa0, 0x6c, 0x83, 0xca, 0x75, 0x0a,
-	0x0f, 0x02, 0x97, 0x26, 0x85, 0x15, 0xde, 0xf6, 0x90, 0x7b, 0x5c, 0x5c, 0xc2, 0x49, 0xe4, 0xf9,
-	0xd1, 0x90, 0xb1, 0xad, 0x8e, 0x45, 0xba, 0x29, 0x1c, 0x3f, 0x48, 0x39, 0x53, 0xb2, 0x55, 0x9d,
-	0x42, 0x5a, 0x2b, 0x49, 0x4f, 0xd2, 0xeb, 0x8e, 0x78, 0x60, 0xae, 0xbf, 0x43, 0x2f, 0xab, 0xc5,
-	0xa6, 0x7f, 0xa0, 0xc5, 0xb5, 0xeb, 0xbf, 0x54, 0x9f, 0xf4, 0x0f, 0x9b, 0xc9, 0x37, 0x83, 0x64,
-	0xe6, 0x96, 0xe0, 0x23, 0x64, 0x6d, 0x45, 0x3c, 0x8f, 0xe6, 0xed, 0x16, 0x1f, 0x5e, 0x74, 0x7f,
-	0x0c, 0x97, 0xba, 0x83, 0x5e, 0x98, 0x80, 0x67, 0x91, 0x70, 0x7b, 0xd6, 0xf0, 0xef, 0xfd, 0xf0,
-	0x1e, 0xe0, 0xb7, 0x37, 0x6e, 0x87, 0xec, 0xcc, 0xe9, 0xf8, 0x7d, 0x9a, 0xbc, 0xee, 0x0b, 0x5d,
-	0xbd, 0xa5, 0xfe, 0x1d, 0xdc, 0xfc, 0x04, 0x00, 0x00, 0xff, 0xff, 0xa5, 0xa1, 0x12, 0x51, 0x16,
-	0x02, 0x00, 0x00,
+	// 301 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x92, 0x41, 0x4b, 0xfb, 0x40,
+	0x10, 0xc5, 0x49, 0xff, 0x49, 0x4a, 0x27, 0xfd, 0x0b, 0x9d, 0x43, 0x8d, 0xc5, 0x43, 0x9b, 0x53,
+	0x45, 0xc8, 0xa1, 0x82, 0x39, 0x79, 0xb0, 0x37, 0x41, 0x7b, 0xd8, 0xe2, 0xc5, 0xdb, 0xea, 0x0e,
+	0x52, 0xb0, 0xd9, 0xd8, 0x4d, 0x8a, 0x5f, 0xdb, 0x6f, 0x20, 0xbb, 0xd9, 0xa6, 0x1b, 0x22, 0xe8,
+	0xc1, 0xdb, 0xcc, 0xf2, 0xde, 0xcc, 0xbc, 0x1f, 0x0b, 0x51, 0x4e, 0x1f, 0x95, 0x4a, 0x8b, 0x9d,
+	0x2c, 0x25, 0x0e, 0xea, 0x86, 0x17, 0x9b, 0xe4, 0x1a, 0xc2, 0x75, 0xc9, 0xcb, 0x4a, 0x21, 0x82,
+	0xff, 0x22, 0x05, 0xc5, 0xde, 0xd4, 0x9b, 0x07, 0xcc, 0xd4, 0x18, 0x43, 0x7f, 0x4b, 0x4a, 0xf1,
+	0x57, 0x8a, 0x7b, 0x53, 0x6f, 0x3e, 0x60, 0x87, 0x36, 0x99, 0x41, 0xb4, 0xe6, 0x7b, 0x62, 0xf4,
+	0x5e, 0x91, 0x2a, 0xb5, 0x59, 0xf0, 0x92, 0x1b, 0xf3, 0x90, 0x99, 0x3a, 0x79, 0x80, 0x61, 0x2d,
+	0x51, 0x85, 0xcc, 0x15, 0xe1, 0x05, 0x84, 0xca, 0xac, 0x32, 0xaa, 0x68, 0x31, 0x4a, 0x9b, 0x33,
+	0xd2, 0xfa, 0x06, 0x66, 0x05, 0xcd, 0xb8, 0x9e, 0x33, 0x6e, 0x06, 0xd1, 0xbd, 0xe4, 0xe2, 0x87,
+	0x8d, 0xb5, 0xe4, 0x6f, 0x36, 0x2e, 0xe1, 0xe4, 0x56, 0x88, 0x95, 0x14, 0x4d, 0xcc, 0x31, 0x84,
+	0xb9, 0x14, 0x74, 0x27, 0xcc, 0xc0, 0xff, 0xcc, 0x76, 0x9a, 0x93, 0xae, 0x1e, 0x77, 0x6f, 0x07,
+	0x4e, 0xb6, 0x4d, 0x2e, 0x61, 0xc4, 0x68, 0x2b, 0xf7, 0xf4, 0x8b, 0x31, 0x8b, 0x4f, 0x0f, 0x82,
+	0x95, 0xbe, 0x10, 0x33, 0xf0, 0x35, 0x3b, 0x1c, 0xbb, 0x17, 0x1f, 0x79, 0x4f, 0x4e, 0x3b, 0xef,
+	0x36, 0x72, 0x06, 0xbe, 0x46, 0xd0, 0x32, 0x3a, 0xd8, 0x5a, 0xc6, 0x16, 0xab, 0x0c, 0xfa, 0x36,
+	0x2c, 0x9e, 0x39, 0x9a, 0x36, 0x80, 0x49, 0x97, 0x20, 0xde, 0x00, 0x1c, 0x13, 0xe2, 0xb9, 0x23,
+	0xe8, 0x04, 0xff, 0xc6, 0xbe, 0x0c, 0x9e, 0xfe, 0xf1, 0x62, 0xf3, 0x1c, 0x9a, 0x9f, 0x79, 0xf5,
+	0x15, 0x00, 0x00, 0xff, 0xff, 0x7c, 0xad, 0x83, 0x38, 0xa8, 0x02, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -287,7 +376,8 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type NexusClient interface {
-	Replicate(ctx context.Context, in *ReplicateRequest, opts ...grpc.CallOption) (*ReplicateResponse, error)
+	Save(ctx context.Context, in *SaveRequest, opts ...grpc.CallOption) (*SaveResponse, error)
+	Load(ctx context.Context, in *LoadRequest, opts ...grpc.CallOption) (*LoadResponse, error)
 	AddNode(ctx context.Context, in *AddNodeRequest, opts ...grpc.CallOption) (*Status, error)
 	RemoveNode(ctx context.Context, in *RemoveNodeRequest, opts ...grpc.CallOption) (*Status, error)
 }
@@ -300,9 +390,18 @@ func NewNexusClient(cc *grpc.ClientConn) NexusClient {
 	return &nexusClient{cc}
 }
 
-func (c *nexusClient) Replicate(ctx context.Context, in *ReplicateRequest, opts ...grpc.CallOption) (*ReplicateResponse, error) {
-	out := new(ReplicateResponse)
-	err := c.cc.Invoke(ctx, "/nexus.api.Nexus/Replicate", in, out, opts...)
+func (c *nexusClient) Save(ctx context.Context, in *SaveRequest, opts ...grpc.CallOption) (*SaveResponse, error) {
+	out := new(SaveResponse)
+	err := c.cc.Invoke(ctx, "/nexus.api.Nexus/Save", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *nexusClient) Load(ctx context.Context, in *LoadRequest, opts ...grpc.CallOption) (*LoadResponse, error) {
+	out := new(LoadResponse)
+	err := c.cc.Invoke(ctx, "/nexus.api.Nexus/Load", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +428,8 @@ func (c *nexusClient) RemoveNode(ctx context.Context, in *RemoveNodeRequest, opt
 
 // NexusServer is the server API for Nexus service.
 type NexusServer interface {
-	Replicate(context.Context, *ReplicateRequest) (*ReplicateResponse, error)
+	Save(context.Context, *SaveRequest) (*SaveResponse, error)
+	Load(context.Context, *LoadRequest) (*LoadResponse, error)
 	AddNode(context.Context, *AddNodeRequest) (*Status, error)
 	RemoveNode(context.Context, *RemoveNodeRequest) (*Status, error)
 }
@@ -338,8 +438,11 @@ type NexusServer interface {
 type UnimplementedNexusServer struct {
 }
 
-func (*UnimplementedNexusServer) Replicate(ctx context.Context, req *ReplicateRequest) (*ReplicateResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method Replicate not implemented")
+func (*UnimplementedNexusServer) Save(ctx context.Context, req *SaveRequest) (*SaveResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Save not implemented")
+}
+func (*UnimplementedNexusServer) Load(ctx context.Context, req *LoadRequest) (*LoadResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Load not implemented")
 }
 func (*UnimplementedNexusServer) AddNode(ctx context.Context, req *AddNodeRequest) (*Status, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AddNode not implemented")
@@ -352,20 +455,38 @@ func RegisterNexusServer(s *grpc.Server, srv NexusServer) {
 	s.RegisterService(&_Nexus_serviceDesc, srv)
 }
 
-func _Nexus_Replicate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ReplicateRequest)
+func _Nexus_Save_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SaveRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(NexusServer).Replicate(ctx, in)
+		return srv.(NexusServer).Save(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/nexus.api.Nexus/Replicate",
+		FullMethod: "/nexus.api.Nexus/Save",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(NexusServer).Replicate(ctx, req.(*ReplicateRequest))
+		return srv.(NexusServer).Save(ctx, req.(*SaveRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Nexus_Load_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LoadRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NexusServer).Load(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/nexus.api.Nexus/Load",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NexusServer).Load(ctx, req.(*LoadRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -411,8 +532,12 @@ var _Nexus_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*NexusServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "Replicate",
-			Handler:    _Nexus_Replicate_Handler,
+			MethodName: "Save",
+			Handler:    _Nexus_Save_Handler,
+		},
+		{
+			MethodName: "Load",
+			Handler:    _Nexus_Load_Handler,
 		},
 		{
 			MethodName: "AddNode",

--- a/pkg/api/nexus.proto
+++ b/pkg/api/nexus.proto
@@ -7,13 +7,22 @@ message Status {
   string message = 2;
 }
 
-message ReplicateResponse {
+message SaveRequest {
+  bytes data = 1;
+}
+
+message SaveResponse {
   Status status = 1;
   bytes data = 2;
 }
 
-message ReplicateRequest {
+message LoadRequest {
   bytes data = 1;
+}
+
+message LoadResponse {
+  Status status = 1;
+  bytes data = 2;
 }
 
 message AddNodeRequest {
@@ -26,7 +35,8 @@ message RemoveNodeRequest {
 }
 
 service Nexus {
-  rpc Replicate (ReplicateRequest) returns (ReplicateResponse);
+  rpc Save (SaveRequest) returns (SaveResponse);
+  rpc Load (LoadRequest) returns (LoadResponse);
   rpc AddNode (AddNodeRequest) returns (Status);
   rpc RemoveNode (RemoveNodeRequest) returns (Status);
 }

--- a/pkg/db/storage.go
+++ b/pkg/db/storage.go
@@ -5,6 +5,7 @@ import "io"
 type Store interface {
 	io.Closer
 	Save([]byte) ([]byte, error)
+	Load([]byte) ([]byte, error)
 
 	Backup() ([]byte, error)
 	Restore([]byte) error


### PR DESCRIPTION
This PR implements support in Nexus for reads. Read requests are considered as byte arrays and the underlying storage handles the actual request.

The PR introduces one of two modes in which Nexus replicas can be started:
1. a mode that always performs quorum based reads in order to guarantee linearizability
2. a mode that does NOT perform a round trip and instead return its local copy of data provided it holds a lease which is periodically checked with other replicas for quorum

Second mode can be used in workloads where the performance costs of a round trip during reads is not desirable. However, in environments where there can be unbounded clock drifts, the second approach can return stale reads when the lease holder assumes its lease validity longer than it should, based on its local clock.

Changes involved:
1. Using the ReadIndex RAFT operation for checking read serviceability.
2. Hooks into storage layer for performing read requests.
3. Support for lease based vs quorum reads during node startup.
4. GRPC API extensions and examples.
5. README updates.
