### PR TITLE
Add raft purgeFile()  | New Config Params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ out/
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 
+bin/

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ can be achieved with few data stores.
 ## Building Nexus
 
 ```bash
-$ mkdir -p ${GOPATH}/src/github.com/flipkart-incubator
-$ cd ${GOPATH}/src/github.com/flipkart-incubator
 $ git clone https://github.com/flipkart-incubator/nexus
 $ cd nexus
 $ make build
@@ -53,19 +51,19 @@ the example sync replication service to make changes to these 3 keyspaces synchr
 Launch the following 3 commands in separate terminal sessions:
 ```bash
 $ <PROJECT_ROOT>/bin/redis_repl \
+      -nexus-cluster-url "http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
+      -nexus-node-url "http://127.0.0.1:9021" \
       -grpcPort 9121 \
-      -nexusClusterUrl "http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
-      -nexusNodeUrl "http://127.0.0.1:9021" \
       -redisPort 6379
 $ <PROJECT_ROOT>/bin/redis_repl \
+      -nexus-cluster-url "http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
+      -nexus-node-url "http://127.0.0.1:9022" \
       -grpcPort 9122 \
-      -nexusClusterUrl "http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
-      -nexusNodeUrl "http://127.0.0.1:9022" \
       -redisPort 6380
 $ <PROJECT_ROOT>/bin/redis_repl \
+      -nexus-cluster-url "http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
+      -nexus-node-url "http://127.0.0.1:9023" \
       -grpcPort 9123 \
-      -nexusClusterUrl "http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
-      -nexusNodeUrl "http://127.0.0.1:9023" \
       -redisPort 6381
 ```
 
@@ -101,19 +99,19 @@ examples to work, please first create a database named `nexus` in each of the 3 
 Launch the following 3 commands in separate terminal sessions:
 ```bash
 $ <PROJECT_ROOT>/bin/mysql_repl \
+      -nexus-cluster-url="http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
+      -nexus-node-url="http://127.0.0.1:9021" \
       -grpcPort=9121 \
-      -nexusClusterUrl="http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
-      -nexusNodeUrl="http://127.0.0.1:9021" \
       -mysqlConnUrl "root:root@tcp(127.0.0.1:33061)/nexus?autocommit=false"
 $ <PROJECT_ROOT>/bin/mysql_repl \
+      -nexus-cluster-url="http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
+      -nexus-node-url="http://127.0.0.1:9022" \
       -grpcPort=9122 \
-      -nexusClusterUrl="http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
-      -nexusNodeUrl="http://127.0.0.1:9022" \
       -mysqlConnUrl "root:root@tcp(127.0.0.1:33062)/nexus?autocommit=false"
 $ <PROJECT_ROOT>/bin/mysql_repl \
+      -nexus-cluster-url="http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
+      -nexus-node-url="http://127.0.0.1:9023" \
       -grpcPort=9123 \
-      -nexusClusterUrl="http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
-      -nexusNodeUrl="http://127.0.0.1:9023" \
       -mysqlConnUrl "root:root@tcp(127.0.0.1:33063)/nexus?autocommit=false"
 ```
 
@@ -141,10 +139,10 @@ At runtime, nodes belonging to an existing Nexus cluster can be removed or new n
 ```bash
 # Launch a node listening at a specific address
 $ <PROJECT_ROOT>/bin/redis_repl \
+      -nexus-cluster-url "http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
+      -nexus-node-url "http://127.0.0.1:9024" \
       -grpcPort 9124 \
-      -nexusClusterUrl "http://127.0.0.1:9021,http://127.0.0.1:9022,http://127.0.0.1:9023" \
-      -nexusNodeUrl "http://127.0.0.1:9024" \
-      -redisPort 6382 \
+      -redisPort 6382 
 # Add this node to the existing cluster
 $ <PROJECT_ROOT>/bin/repl 127.0.0.1:9121 addNode "http://127.0.0.1:9024"
 Current cluster members:

--- a/internal/raft/replicator.go
+++ b/internal/raft/replicator.go
@@ -91,6 +91,7 @@ func (this *replicator) Start() {
 	go this.readCommits()
 	go this.readReadStates()
 	this.node.startRaft()
+	go this.node.purgeFile()
 }
 
 func (this *replicator) ListMembers() (uint64, map[uint64]string) {

--- a/internal/raft/replicator_test.go
+++ b/internal/raft/replicator_test.go
@@ -47,7 +47,7 @@ func testListMembers(t *testing.T) {
 
 func testSaveLoadLargeData(t *testing.T) {
 	var reqs []*kvReq
-	var iterations = 100
+	var iterations = 20
 	// Saving
 	writePeer := clus.peers[0]
 	runId := writePeer.id

--- a/internal/raft/replicator_test.go
+++ b/internal/raft/replicator_test.go
@@ -34,6 +34,7 @@ func TestReplicator(t *testing.T) {
 
 	t.Run("testListMembers", testListMembers)
 	t.Run("testSaveLoadData", testSaveLoadData)
+	t.Run("testSaveLoadLargeData", testSaveLoadLargeData)
 	t.Run("testLoadDuringRestarts", testLoadDuringRestarts)
 	t.Run("testForNewNexusNodeJoinLeaveCluster", testForNewNexusNodeJoinLeaveCluster)
 	t.Run("testForNodeRestart", testForNodeRestart)
@@ -42,6 +43,33 @@ func TestReplicator(t *testing.T) {
 func testListMembers(t *testing.T) {
 	members := strings.Split(clusterUrl, ",")
 	clus.assertMembers(t, members)
+}
+
+func testSaveLoadLargeData(t *testing.T) {
+	var reqs []*kvReq
+	var iterations = 100
+	// Saving
+	writePeer := clus.peers[0]
+	runId := writePeer.id
+
+	for i := 0; i < iterations; i++ {
+		req1 := &kvReq{fmt.Sprintf("Key:K%d#%d", runId, i), fmt.Sprintf("Val:%d#%d", runId, i)}
+		writePeer.save(t, req1)
+		reqs = append(reqs, req1)
+		t.Logf("Write KEY : %s", req1.Key)
+	}
+
+	//assertions
+	clus.assertDB(t, reqs...)
+
+	//Read
+	for i := 0; i < iterations; i++ {
+		req1 := &kvReq{fmt.Sprintf("Key:K%d#%d", runId, i), fmt.Sprintf("Val:%d#%d", runId, i)}
+		actVal := writePeer.load(t, req1).(string)
+		if req1.Val != actVal {
+			t.Errorf("Value mismatch for peer: %d. Key: %s, Expected Value: %s, Actual Value: %s", writePeer.id, req1.Key, req1.Val, actVal)
+		}
+	}
 }
 
 func testSaveLoadData(t *testing.T) {
@@ -286,6 +314,10 @@ func newPeerWithDB(id int, db *inMemKVStore) (*peer, error) {
 		raft.ClusterUrl(clusterUrl),
 		raft.ReplicationTimeout(replTimeout),
 		raft.LeaseBasedReads(false),
+		raft.SnapshotCatchUpEntries(5),
+		raft.SnapshotCount(10),
+		raft.MaxWALFiles(2),
+		raft.MaxSnapFiles(2),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/raft/replicator_test.go
+++ b/internal/raft/replicator_test.go
@@ -47,7 +47,7 @@ func testListMembers(t *testing.T) {
 
 func testSaveLoadLargeData(t *testing.T) {
 	var reqs []*kvReq
-	var iterations = 20
+	iterations := 20
 	// Saving
 	writePeer := clus.peers[0]
 	runId := writePeer.id

--- a/pkg/raft/opts.go
+++ b/pkg/raft/opts.go
@@ -79,7 +79,7 @@ func init() {
 
 	flag.IntVar(&opts.maxSnapFiles, "max-snapshots", defaultMaxSNAP, "Maximum number of snapshot files to retain (0 is unlimited)")
 	flag.IntVar(&opts.maxWALFiles, "max-wals", defaultMaxWAL, "Maximum number of wal files to retain (0 is unlimited)")
-	flag.Int64Var(&opts.snapshotCount, "snapshot-count", defaultSnapshotCount, "Number of committed transactions to trigger a snapshot to disk. (default 100K)")
+	flag.Int64Var(&opts.snapshotCount, "snapshot-count", defaultSnapshotCount, "Number of committed transactions to trigger a snapshot to disk. (default 10K)")
 	flag.Int64Var(&opts.snapshotCatchUpEntries, "snapshot-catchup-entries", defaultSnapshotCatchUpEntries, "Number of entries for a slow follower to catch-up after compacting the raft storage entries (Default 5K)")
 }
 

--- a/pkg/raft/opts.go
+++ b/pkg/raft/opts.go
@@ -77,10 +77,10 @@ func init() {
 	flag.BoolVar(&opts.leaseBasedReads, "nexus-lease-based-reads", true, "Perform reads using RAFT leader leases")
 	flag.StringVar(&opts.statsdAddr, "nexus-statsd-addr", "", "StatsD server address (host:port) for relaying various metrics")
 
-	flag.IntVar(&opts.maxSnapFiles, "max-snapshots", defaultMaxSNAP, "Maximum number of snapshot files to retain (0 is unlimited)")
-	flag.IntVar(&opts.maxWALFiles, "max-wals", defaultMaxWAL, "Maximum number of wal files to retain (0 is unlimited)")
-	flag.Int64Var(&opts.snapshotCount, "snapshot-count", defaultSnapshotCount, "Number of committed transactions to trigger a snapshot to disk. (default 10K)")
-	flag.Int64Var(&opts.snapshotCatchUpEntries, "snapshot-catchup-entries", defaultSnapshotCatchUpEntries, "Number of entries for a slow follower to catch-up after compacting the raft storage entries (Default 5K)")
+	flag.IntVar(&opts.maxSnapFiles, "nexus-max-snapshots", defaultMaxSNAP, "Maximum number of snapshot files to retain (0 is unlimited)")
+	flag.IntVar(&opts.maxWALFiles, "nexus-max-wals", defaultMaxWAL, "Maximum number of wal files to retain (0 is unlimited)")
+	flag.Int64Var(&opts.snapshotCount, "nexus-snapshot-count", defaultSnapshotCount, "Number of committed transactions to trigger a snapshot to disk. (default 10K)")
+	flag.Int64Var(&opts.snapshotCatchUpEntries, "nexus-snapshot-catchup-entries", defaultSnapshotCatchUpEntries, "Number of entries for a slow follower to catch-up after compacting the raft storage entries (Default 5K)")
 }
 
 func OptionsFromFlags() []Option {
@@ -308,8 +308,8 @@ func (this *options) SnapshotCatchUpEntries() uint64 {
 
 func MaxSnapFiles(count int) Option {
 	return func(opts *options) error {
-		if count < 0 {
-			return errors.New("maxSnapFiles cannot be negative")
+		if count < 1 {
+			return errors.New("maxSnapFiles cannot be < 1")
 		}
 		opts.maxSnapFiles = count
 		return nil
@@ -318,8 +318,8 @@ func MaxSnapFiles(count int) Option {
 
 func MaxWALFiles(count int) Option {
 	return func(opts *options) error {
-		if count < 0 {
-			return errors.New("maxWALFiles cannot be negative")
+		if count < 1 {
+			return errors.New("maxWALFiles cannot be < 1")
 		}
 		opts.maxWALFiles = count
 		return nil
@@ -328,8 +328,8 @@ func MaxWALFiles(count int) Option {
 
 func SnapshotCount(count int64) Option {
 	return func(opts *options) error {
-		if count < 0 {
-			return errors.New("snapshotCount cannot be negative")
+		if count < 1 {
+			return errors.New("snapshotCount cannot be < 1")
 		}
 		opts.snapshotCount = count
 		return nil
@@ -338,8 +338,8 @@ func SnapshotCount(count int64) Option {
 
 func SnapshotCatchUpEntries(count int64) Option {
 	return func(opts *options) error {
-		if count < 0 {
-			return errors.New("snapshotCatchUpEntries cannot be negative")
+		if count < 1 {
+			return errors.New("snapshotCatchUpEntries cannot be < 1")
 		}
 		opts.snapshotCatchUpEntries = count
 		return nil

--- a/pkg/raft/opts.go
+++ b/pkg/raft/opts.go
@@ -308,6 +308,9 @@ func (this *options) SnapshotCatchUpEntries() uint64 {
 
 func MaxSnapFiles(count int) Option {
 	return func(opts *options) error {
+		if count < 0 {
+			return errors.New("maxSnapFiles cannot be negative")
+		}
 		opts.maxSnapFiles = count
 		return nil
 	}
@@ -315,6 +318,9 @@ func MaxSnapFiles(count int) Option {
 
 func MaxWALFiles(count int) Option {
 	return func(opts *options) error {
+		if count < 0 {
+			return errors.New("maxWALFiles cannot be negative")
+		}
 		opts.maxWALFiles = count
 		return nil
 	}
@@ -322,6 +328,9 @@ func MaxWALFiles(count int) Option {
 
 func SnapshotCount(count int64) Option {
 	return func(opts *options) error {
+		if count < 0 {
+			return errors.New("snapshotCount cannot be negative")
+		}
 		opts.snapshotCount = count
 		return nil
 	}
@@ -329,6 +338,9 @@ func SnapshotCount(count int64) Option {
 
 func SnapshotCatchUpEntries(count int64) Option {
 	return func(opts *options) error {
+		if count < 0 {
+			return errors.New("snapshotCatchUpEntries cannot be negative")
+		}
 		opts.snapshotCatchUpEntries = count
 		return nil
 	}

--- a/pkg/raft/opts.go
+++ b/pkg/raft/opts.go
@@ -308,8 +308,8 @@ func (this *options) SnapshotCatchUpEntries() uint64 {
 
 func MaxSnapFiles(count int) Option {
 	return func(opts *options) error {
-		if count < 1 {
-			return errors.New("maxSnapFiles cannot be < 1")
+		if count < 0 {
+			return errors.New("maxSnapFiles cannot be negative")
 		}
 		opts.maxSnapFiles = count
 		return nil
@@ -328,8 +328,8 @@ func MaxWALFiles(count int) Option {
 
 func SnapshotCount(count int64) Option {
 	return func(opts *options) error {
-		if count < 0 {
-			return errors.New("snapshotCount cannot be negative")
+		if count < 1 {
+			return errors.New("snapshotCount cannot be < 1")
 		}
 		opts.snapshotCount = count
 		return nil

--- a/pkg/raft/opts.go
+++ b/pkg/raft/opts.go
@@ -318,8 +318,8 @@ func MaxSnapFiles(count int) Option {
 
 func MaxWALFiles(count int) Option {
 	return func(opts *options) error {
-		if count < 1 {
-			return errors.New("maxWALFiles cannot be < 1")
+		if count < 0 {
+			return errors.New("maxWALFiles cannot be negative")
 		}
 		opts.maxWALFiles = count
 		return nil
@@ -328,8 +328,8 @@ func MaxWALFiles(count int) Option {
 
 func SnapshotCount(count int64) Option {
 	return func(opts *options) error {
-		if count < 1 {
-			return errors.New("snapshotCount cannot be < 1")
+		if count < 0 {
+			return errors.New("snapshotCount cannot be negative")
 		}
 		opts.snapshotCount = count
 		return nil

--- a/pkg/raft/opts.go
+++ b/pkg/raft/opts.go
@@ -68,7 +68,6 @@ var (
 )
 
 func init() {
-
 	flag.StringVar(&opts.nodeUrlStr, "nexus-node-url", "", "Url for the Nexus service to be started on this node (format: http://<local_node>:<port_num>)")
 	flag.StringVar(&opts.logDir, "nexus-log-dir", "/tmp/logs", "Dir for storing RAFT logs")
 	flag.StringVar(&opts.snapDir, "nexus-snap-dir", "/tmp/snap", "Dir for storing RAFT snapshots")

--- a/pkg/raft/opts.go
+++ b/pkg/raft/opts.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultSnapshotCount int64 = 100000
+	defaultSnapshotCount int64 = 10000
 	// defaultSnapshotCatchUpEntries is the number of entries for a slow follower
 	// to catch-up after compacting the raft storage entries.
 	// We expect the follower has a millisecond level latency with the leader.


### PR DESCRIPTION
- Move to `dashed-config` naming scheme for config params
- Raft `purgeFile()` to cleanup old wal & snap files